### PR TITLE
Use image_size gem instead of identify command

### DIFF
--- a/lib/mini_paperclip.rb
+++ b/lib/mini_paperclip.rb
@@ -8,6 +8,7 @@ require "active_support/number_helper"
 require "mini_magick"
 require "mimemagic"
 require "aws-sdk-s3"
+require "image_size"
 
 require "mini_paperclip/attachment"
 require "mini_paperclip/class_methods"

--- a/mini_paperclip.gemspec
+++ b/mini_paperclip.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activemodel"
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "aws-sdk-s3"
+  spec.add_runtime_dependency "image_size"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/spec/mini_paperclip/attachment_spec.rb
+++ b/spec/mini_paperclip/attachment_spec.rb
@@ -96,6 +96,19 @@ RSpec.describe MiniPaperclip::Attachment do
     expect(a.waiting_write_file).to_not be_closed
   end
 
+  it "#assign with invalid File" do
+    a = MiniPaperclip::Attachment.new(record, :image)
+    Tempfile.create(['spec']) do |f|
+      f.write('test')
+      f.flush
+      a.assign(f)
+      expect(record.image_content_type).to eq(nil)
+      expect(record.image_file_size).to eq(4)
+      expect(record.image_file_name).to eq(File.basename(f.path))
+    end
+    expect(a.waiting_write_file).to_not be_closed
+  end
+
   it "#assign with empty string" do
     a = MiniPaperclip::Attachment.new(record, :image)
     file = Rack::Test::UploadedFile.new "spec/paperclip.jpg", 'image/jpeg'

--- a/spec/mini_paperclip/validators/geometry_validator_spec.rb
+++ b/spec/mini_paperclip/validators/geometry_validator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe MiniPaperclip::Validators::GeometryValidator do
-  it "#validate_eaxh with invalid image" do
+  it "#validate_each with invalid image" do
     validator = MiniPaperclip::Validators::GeometryValidator.new(
       attributes: :img,
       width: { less_than_or_equal_to: 1000 },

--- a/spec/mini_paperclip/validators/geometry_validator_spec.rb
+++ b/spec/mini_paperclip/validators/geometry_validator_spec.rb
@@ -1,4 +1,18 @@
 RSpec.describe MiniPaperclip::Validators::GeometryValidator do
+  it "#validate_eaxh with invalid image" do
+    validator = MiniPaperclip::Validators::GeometryValidator.new(
+      attributes: :img,
+      width: { less_than_or_equal_to: 1000 },
+    )
+    Tempfile.create(['spec']) do |f|
+      mock = double('Record')
+      attachment = double('Attachment')
+      allow(attachment).to receive(:waiting_write_file).and_return(f)
+      expect(mock).to_not receive(:errors)
+      validator.validate_each(mock, :img, attachment)
+    end
+  end
+
   it "#validate_each with valid geometry width" do
     validator = MiniPaperclip::Validators::GeometryValidator.new(
       attributes: :img,


### PR DESCRIPTION
[image_size](https://github.com/toy/image_size) is so cool.
It will be able to reduce memory usage on geometry validator.