### PR TITLE
Skip rails main branch test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,6 @@ jobs:
         gemfile:
           - gemfiles/rails_52.gemfile
           - gemfiles/rails_60.gemfile
-          - gemfiles/rails_head.gemfile
-        exclude:
-          - ruby: 2.5
-            gemfile: gemfiles/rails_head.gemfile
-          - ruby: 2.6
-            gemfile: gemfiles/rails_head.gemfile
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
In now, rails head test is failed by cannot resolve rails v7.0.0-alpha from rubygems.orb, because it's not released yet. #14 

(But it succeeded in my local machine. I don't know why it fails on github actions.)
So I decided to skip the rails head test until its release.