### PR TITLE
Enable to pass s3_client_options for s3 compatible object storage

### DIFF
--- a/lib/mini_paperclip.rb
+++ b/lib/mini_paperclip.rb
@@ -37,6 +37,7 @@ module MiniPaperclip
         keep_old_files: false,
         read_timeout: 60,
         logger: Logger.new($stdout),
+        s3_client_options: {},
       )
     end
   end

--- a/lib/mini_paperclip/config.rb
+++ b/lib/mini_paperclip/config.rb
@@ -15,6 +15,7 @@ module MiniPaperclip
     :s3_bucket_name,
     :s3_acl,
     :s3_cache_control,
+    :s3_client_options,
     :interpolates,
     :keep_old_files,
     :read_timeout,

--- a/lib/mini_paperclip/storage/s3.rb
+++ b/lib/mini_paperclip/storage/s3.rb
@@ -5,7 +5,7 @@ module MiniPaperclip
     class S3 < Base
       def write(style, file)
         debug("writing by S3 to bucket:#{@config.s3_bucket_name},key:#{s3_object_key(style)}")
-        Aws::S3::Client.new.put_object(
+        Aws::S3::Client.new(@config.s3_client_options).put_object(
           acl: @config.s3_acl,
           cache_control: @config.s3_cache_control,
           content_type: @attachment.content_type,
@@ -26,7 +26,7 @@ module MiniPaperclip
       end
 
       def exists?(style)
-        Aws::S3::Client.new.head_object(
+        Aws::S3::Client.new(@config.s3_client_options).head_object(
           bucket: @config.s3_bucket_name,
           key: s3_object_key(style),
         )
@@ -42,7 +42,7 @@ module MiniPaperclip
       def do_delete_files
         return if @deletes.empty?
         debug("deleting by S3 to bucket:#{@config.s3_bucket_name},objects:#{@deletes}")
-        Aws::S3::Client.new.delete_objects(
+        Aws::S3::Client.new(@config.s3_client_options).delete_objects(
           bucket: @config.s3_bucket_name,
           delete: {
             objects: @deletes,
@@ -54,7 +54,7 @@ module MiniPaperclip
       def open(style)
         Tempfile.new(['MiniPaperclip::Storage::S3']).tap do |response_target|
           response_target.binmode
-          Aws::S3::Client.new.get_object(
+          Aws::S3::Client.new(@config.s3_client_options).get_object(
             bucket: @config.s3_bucket_name,
             key: s3_object_key(style),
             response_target: response_target,


### PR DESCRIPTION
## What

When using mini_paperclip with S3 compatible object storage like minio, digitalocean spaces, wasabi, and cloudflare r2, the user
should pass endpoint, force_path_style, and some options to `Aws::S3::Client.new` as its option.

This change makes enables to pass any options to `Aws::S3::Client.new`.

## example
https://gist.github.com/unasuke/81c3a0e7f06809e77d3bd83e25a383a0